### PR TITLE
Add example using persona file

### DIFF
--- a/examples/compose/6_persona_file.py
+++ b/examples/compose/6_persona_file.py
@@ -1,0 +1,39 @@
+"""Compose a song using sound prompts parsed from a persona file."""
+
+from pathlib import Path
+from riff_api import RiffAPIClient, SoundPrompt
+
+
+def load_persona_prompts(path: Path) -> list[SoundPrompt]:
+    """Read `key: value` lines from a persona file as individual sound prompts."""
+    prompts: list[SoundPrompt] = []
+    with path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line or ":" not in line:
+                continue
+            _, desc = line.split(":", 1)
+            desc = desc.strip()
+            if desc:
+                prompts.append(SoundPrompt(text=desc))
+    return prompts
+
+
+persona_file = Path(__file__).resolve().parents[1] / "personas" / "elias_driftborn.ai"
+
+sound_prompts = load_persona_prompts(persona_file)
+
+lyrics = """\
+Wandering through echoes of the unknown,
+voices intertwine in sacred tone.
+""".strip()
+
+client = RiffAPIClient()
+response = client.compose(
+    sound_prompts=sound_prompts,
+    lyrics=lyrics,
+)
+
+output_path = "6_persona_file.m4a"
+client.save_audio(response.audio_b64, output_path)
+print(f"Saved song to {output_path}")

--- a/examples/personas/elias_driftborn.ai
+++ b/examples/personas/elias_driftborn.ai
@@ -1,0 +1,8 @@
+Voice Tone: Baritone with analytical cadence; slight rasp when invoking uncertainty
+Accent: Neutral American academic, with flickers of hollow spatial resonance
+Style Prompt: Spiritual electro-duet with ambient noise floor and harmonic vocal illusion
+Mood: sacred, surreal, pulse-driven
+Tempo: oscillating, breath-led
+Acoustic Space: circular sound dome, reverb-tail heavy
+Sound Palette: live voice modulation, spectral beatbox, ambient drone bed, harmonic bloom FX
+Auditory Persona Cue: "We only model the part of the heat we see." (delivered like a postscript from a lecture no one stayed to hear)


### PR DESCRIPTION
## Summary
- add `examples/compose/6_persona_file.py` showing how to load sound prompts from a persona file
- provide sample persona description in `examples/personas/elias_driftborn.ai`

## Testing
- `python -m py_compile examples/compose/6_persona_file.py`

------
https://chatgpt.com/codex/tasks/task_b_68561c45f7d88325968d69eac4a68d6e